### PR TITLE
Improve HTML5 validation error messages with contextual information

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,15 @@
 History
 -------
 
+0.7.2 (2026-02-17)
+++++++++++++++++++
+
+* improved strict HTML5 validation error messages with clear context and location
+* error messages now show exact line and column numbers where validation fails
+* added visual context (3 lines before/after) with pointer to exact error location
+* multiple validation errors now reported individually with their own context
+* error messages are now actionable instead of showing cryptic stack traces
+
 0.7.1 (2026-02-13)
 ++++++++++++++++++
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,7 +20,7 @@ SECRET_KEY = "da3_88ph4@26ol_!06kbpeuy-nl+ex%zuxbsnzqhd=42=jp-pf"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: List[str] = []
+ALLOWED_HOSTS: List[str] = ["testserver"]
 
 # Application definition
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -837,6 +837,38 @@ class AssertElementStrictValidationTests(AssertElementMixin, TestCase):
             html="strict",
         )
 
+    @unittest.skipUnless(HAS_HTML5LIB, "html5lib not installed")
+    def test_strict_mode_error_message_format(self):
+        """Strict mode error messages should include line number, context, and pointer."""
+        html = """<!DOCTYPE html>
+<html>
+<head><title>Test</title></head>
+<body>
+    <div id="test">
+        <p>Text</p>
+    </div class="invalid">
+</body>
+</html>"""
+
+        error_raised = False
+        error_msg = ""
+        try:
+            self.assertElementContains(html, "p", "<p>Text</p>", html="strict")
+        except AssertionError as e:
+            error_raised = True
+            error_msg = str(e)
+
+        # Verify error was raised
+        self.assertTrue(error_raised, "Should have raised AssertionError for invalid HTML")
+
+        # Verify error message contains expected components
+        self.assertIn("HTML5 Validation Error at line", error_msg)
+        self.assertIn("End tag contains unexpected attributes", error_msg)
+        self.assertIn("Context:", error_msg)
+        self.assertIn(">>>", error_msg)  # Line marker
+        self.assertIn("^", error_msg)  # Column pointer
+        self.assertIn('</div class="invalid">', error_msg)  # The problematic line
+
     def test_standard_mode_with_bytes_content(self):
         """Standard mode should handle byte content correctly."""
         html_bytes = b"<html><body><div>Test</div></body></html>"


### PR DESCRIPTION
- Add line and column numbers to error messages
- Show 3 lines of context before/after error location
- Add visual markers (>>> and ^) to highlight exact error position
- Display multiple validation errors individually with context
- Refactor: Extract _content_to_str() helper to eliminate duplication
- Refactor: Extract _format_attrs() to remove duplicate attribute formatting
- Remove defensive try/except for error message formatting

This makes HTML5 validation errors actionable instead of cryptic stack traces. Users can now immediately see where in their rendered HTML the error occurs.